### PR TITLE
WIP: Decouple HTTP client

### DIFF
--- a/src/API/CurlClient.php
+++ b/src/API/CurlClient.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace Keepa\API;
+
+class CurlClient implements HttpClientInterface
+{
+    /**
+     * @var resource
+     */
+    protected $ch;
+
+    /**
+     * @var array
+     */
+    protected $postData = [];
+
+    /**
+     * @var mixed
+     */
+    protected $body;
+
+    /**
+     * @inheritDoc
+     */
+    public function __construct()
+    {
+        $this->ch = curl_init();
+        $this->setOpt(CURLOPT_ENCODING, 'gzip');
+        $this->setOpt(CURLOPT_RETURNTRANSFER, true);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setUrl($url)
+    {
+        $this->setOpt(CURLOPT_URL, $url);
+        return $this;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setUserAgent($agent)
+    {
+        $this->setOpt(CURLOPT_USERAGENT, $agent);
+        return $this;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setPostData($data)
+    {
+        $this->postData = array_merge($this->postData, $data);
+        $this->setOpt(CURLOPT_POST, true);
+        $this->setOpt(CURLOPT_POSTFIELDS, $this->postData);
+        return $this;
+    }
+
+    /**
+     * @inheritDoc
+     * @throws \Exception
+     */
+    public function get()
+    {
+        $this->body = curl_exec($this->ch);
+        if($this->body === false)
+            throw new \Exception(curl_error($this->ch));
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getResponseCode()
+    {
+        return curl_getinfo($this->ch, CURLINFO_HTTP_CODE);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getBody()
+    {
+        return $this->body;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function __destruct()
+    {
+        curl_close($this->ch);
+    }
+
+    /**
+     * @param $key
+     * @param $value
+     */
+    protected function setOpt($key, $value)
+    {
+        curl_setopt($this->ch, $key, $value);
+    }
+
+
+}

--- a/src/API/HttpClientInterface.php
+++ b/src/API/HttpClientInterface.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Keepa\API;
+
+interface HttpClientInterface
+{
+    /**
+     * HttpClientInterface constructor
+     */
+    public function __construct();
+
+    /**
+     * @param string $url
+     * @return $this
+     */
+    public function setUrl($url);
+
+    /**
+     * @param string $agent
+     * @return $this
+     */
+    public function setUserAgent($agent);
+
+    /**
+     * @param array $data
+     * @return string
+     */
+    public function setPostData($data);
+
+    /**
+     * Execute the request
+     * @return void
+     */
+    public function get();
+
+    /**
+     * @return int response code
+     */
+    public function getResponseCode();
+
+    /**
+     * @return string body
+     */
+    public function getBody();
+
+    /**
+     * Cleaning-up
+     */
+    public function __destruct();
+}

--- a/test.php
+++ b/test.php
@@ -13,6 +13,7 @@ use Keepa\KeepaAPI;
 use Keepa\objects\AmazonLocale;
 
 $api = new KeepaAPI("771ftntmq9f04bpasd0j903sh7le7tk8vo0irulj98cm6ulgl8ieu805ctmpdf4k");
+$api->setHttpClient(new \Keepa\API\CurlClient);
 $r = Request::getProductRequest(AmazonLocale::DE, 0, "2015-12-31", "2018-01-01", 0, true, ['B001G73S50']);
 
 while (true) {


### PR DESCRIPTION
This is a WIP to allow discussing this matter.
I would rather see the HTTP client decoupled from the core KeepAPI. 
This would allow the user to choose whatever HttpClient suffices. 
For example, I would use Guzzle because it supports mocking requests, in that way I can test the Keepa API without actually hitting it. 

This should be thoroughly tested, though. 