### PR TITLE
Use 'continue 2' to break look in switch

### DIFF
--- a/src/KeepaAPI.php
+++ b/src/KeepaAPI.php
@@ -149,7 +149,7 @@ class KeepaAPI
                     $lastResponse = $result;
                     $retry++;
                     $delay = min(2 * $expoDelay + 100, self::MAX_DELAY);
-                    continue;
+                    continue 2;
                 default:
                     return $result;
             }


### PR DESCRIPTION
> Note: In PHP the switch statement is considered a looping structure for the purposes of continue. **continue behaves like break** (when no arguments are passed). If a switch is inside a loop, continue 2 will continue with the next iteration of the outer loop.
[php.net/control-structures.continue](http://php.net/manual/en/control-structures.continue.php)

The intention here, as it seems to me, is to `continue` the outer loop. 

In PHP 7.3 there's an explicit error thrown when this pattern is detected.
Use either `break` in a `switch` to break the current `case` or `continue 2` to continue the outer loop. 