### PR TITLE
Implement usage of $days parameter in getDetailedProductRequest

### DIFF
--- a/src/API/Request.php
+++ b/src/API/Request.php
@@ -284,7 +284,7 @@ class Request
      * @param array $params Array of additional request parameters
      * @return Request ready to send request.
      */
-    public static function getDetailedProductRequest($domainID, $offers, $statsStartDate, $statsEndDate, $buybox, $update, $history, $rental, $rating, $fbafees, $onlyLiveOffers, $days, array $asins, $params = null)
+    public static function getDetailedProductRequest($domainID, $offers, $statsStartDate, $statsEndDate, $buybox, $update, $history, $rental, $rating, $fbafees, $onlyLiveOffers, int $days, array $asins, $params = null)
     {
         $r = new Request();
         $r->path = "product";
@@ -300,6 +300,13 @@ class Request
         $r->parameter["fbafees"] = $fbafees ? "1" : "0";
         $r->parameter["only-live-offers"] = $onlyLiveOffers ? "1" : "0";
         $r->parameter["history"] = $history ? "1" : "0";
+
+        if (
+            isset($days) &&
+            $days >= 0
+        ) {
+            $r->parameter["days"] = $days;
+        }
 
         if ($statsStartDate != null && $statsEndDate != null)
             $r->parameter["stats"] = $statsStartDate . "," . $statsEndDate;


### PR DESCRIPTION
I've noticed a small oversight in the Request class, specifically in the getDetailedProductRequest method. The method documentation mentions a $days parameter, described as "If specified and has positive value X the product object will limit all historical data to the recent X days." However, this parameter is not being used within the method.

**Issue Description:**
The $days parameter is intended to limit the scope of historical data returned for a product. However, in the current implementation of getDetailedProductRequest, the $days parameter is received but not utilized in any part of the method. This results in the inability to limit the historical data as described in the method's documentation.
References issue #38

**Proposed Changes:**
I propose to modify the getDetailedProductRequest method to include the functionality of the $days parameter. This would involve adding a few lines of code to ensure that the historical data returned is limited to the specified number of days.